### PR TITLE
JSON encoder

### DIFF
--- a/lib/airbrake/channel.ex
+++ b/lib/airbrake/channel.ex
@@ -15,7 +15,7 @@ defmodule Airbrake.Channel do
           super(channel_name, msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, %{message: msg}, %{channel: channel_name})
+            send_to_airbrake(exception, socket_data(socket), message_data(msg), %{channel: channel_name})
         end
       end
 
@@ -24,7 +24,7 @@ defmodule Airbrake.Channel do
           super(msg_type, msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, %{message: msg}, %{msg_type: msg_type})
+            send_to_airbrake(exception, socket_data(socket), message_data(msg), %{msg_type: msg_type})
         end
       end
 
@@ -33,7 +33,7 @@ defmodule Airbrake.Channel do
           super(msg, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, %{message: msg})
+            send_to_airbrake(exception, socket_data(socket), message_data(msg))
         end
       end
 
@@ -42,8 +42,16 @@ defmodule Airbrake.Channel do
           super(reason, socket)
         rescue
           exception ->
-            send_to_airbrake(exception, socket.assigns, %{reason: reason})
+            send_to_airbrake(exception, socket_data(socket), %{reason: reason})
         end
+      end
+
+      defp socket_data(socket) do
+        %{assigns: socket.assigns}
+      end
+
+      defp message_data(message) do
+        %{message: message}
       end
 
       defp send_to_airbrake(exception, session, params, context \\ nil) do

--- a/lib/airbrake/json_encoder.ex
+++ b/lib/airbrake/json_encoder.ex
@@ -1,0 +1,72 @@
+alias Airbrake.JSONEncoder
+
+defprotocol Airbrake.JSONEncoder do
+  @fallback_to_any true
+
+  def encode(value)
+end
+
+defimpl Airbrake.JSONEncoder, for: Tuple do
+  def encode(tuple) do
+    items =
+      tuple
+      |> Tuple.to_list
+      |> Enum.map(&JSONEncoder.encode/1)
+      |> Enum.map(&escape/1)
+      |> Enum.join(", ")
+
+    "\"{#{items}}\""
+  end
+
+  defp escape(string) do
+    String.replace(string, "\"", "\\\"")
+  end
+end
+
+defimpl Airbrake.JSONEncoder, for: Map do
+  defp encode_name(value) when is_binary(value) do
+    value
+  end
+
+  defp encode_name(value) do
+    case String.Chars.impl_for(value) do
+      nil ->
+        raise "expected a String.Chars encodable value, got: #{inspect(value)}"
+      impl ->
+        impl.to_string(value)
+    end
+  end
+
+  def encode(map) when map_size(map) < 1, do: "{}"
+  def encode(map) do
+    fun = &[?,, JSONEncoder.encode(encode_name(&1)), ?:,
+            JSONEncoder.encode(:maps.get(&1, map)) | &2]
+    "{#{tl(:lists.foldl(fun, [], :maps.keys(map)))}}"
+  end
+end
+
+defimpl Airbrake.JSONEncoder, for: List do
+  def encode(list) do
+    fun = &[?,, JSONEncoder.encode(&1) | &2]
+    "[#{tl(:lists.foldr(fun, [], list))}]"
+  end
+end
+
+defimpl Airbrake.JSONEncoder, for: Any do
+  defp failed_encoding(value) do
+    Poison.encode!(inspect(value))
+  end
+
+  def encode(%{__struct__: struct_name} = struct) do
+    Map.from_struct(struct)
+    |> Map.put("__struct__", struct_name)
+    |> JSONEncoder.Map.encode
+  end
+  def encode(value) do
+    try do
+      Poison.encode!(value)
+    rescue _ -> failed_encoding(value)
+    catch _ -> failed_encoding(value)
+    end
+  end
+end

--- a/test/airbrake/json_encoder_test.exs
+++ b/test/airbrake/json_encoder_test.exs
@@ -1,0 +1,17 @@
+defmodule SomeStruct do
+  defstruct [:data]
+end
+
+defmodule Airbrake.JSONEncoderTest do
+  use ExUnit.Case
+  alias Airbrake.JSONEncoder
+
+  test "encoding various types" do
+    assert "{\"b\":\"{2, 3}\",\"a\":\"#{inspect(self())}\"}" ==
+      JSONEncoder.encode(%{ :a => self(), "b" => {2, 3}})
+    assert "{\"__struct__\":\"Elixir.SomeStruct\",\"data\":\"test\"}" ==
+      JSONEncoder.encode(%SomeStruct{data: "test"})
+    assert "\"{\\\"abc\\\", \\\"#PID<0.209.0>\\\", 123}\"" ==
+      JSONEncoder.encode({"abc", self(), 123})
+  end
+end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -13,7 +13,7 @@ defmodule Airbrake.PayloadTest do
   end
 
   def get_payload(options \\ []) do
-    apply Payload, :new, List.insert_at(get_problem, -1, options)
+    apply Payload, :new, List.insert_at(get_problem(), -1, options)
   end
 
   def get_error(options \\ []) do
@@ -47,7 +47,7 @@ defmodule Airbrake.PayloadTest do
   test "it generates correct stacktraces when the current file was a script" do
     assert [%{file: "unknown", line: 0, function: _},
             %{file: "test/airbrake/payload_test.exs", line: 9, function: "Elixir.Airbrake.PayloadTest.get_problem/0"},
-            %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _] = get_error.backtrace
+            %{file: "test/airbrake/payload_test.exs", line: _, function: _} | _] = get_error().backtrace
   end
 
   # NOTE: Regression test
@@ -63,16 +63,16 @@ defmodule Airbrake.PayloadTest do
   end
 
   test "it reports the error class" do
-    assert "UndefinedFunctionError" == get_error.type
+    assert "UndefinedFunctionError" == get_error().type
   end
 
   test "it reports the error message" do
-    assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error.message
+    assert "function Harbour.cats/1 is undefined (module Harbour is not available)" == get_error().message
   end
 
   test "it reports the notifier" do
     assert %{name: "Airbrake Elixir",
              url: "https://github.com/romul/airbrake-elixir",
-             version: _} = get_payload.notifier
+             version: _} = get_payload().notifier
   end
 end


### PR DESCRIPTION
Benefits to the custom encoder:
* Types not handled or disabled by Poison, like `Elixir.Ecto.Association.NotLoaded`, can be implemented only within the context of the Airbrake library.
* Maps and lists can be translated to objects and arrays in JavaScript so that Airbrake can display them with indentation.